### PR TITLE
fix typings for import as es6

### DIFF
--- a/dist/types/browser-detect.d.ts
+++ b/dist/types/browser-detect.d.ts
@@ -1,5 +1,5 @@
-import { BrowserDetectInfo } from './interface';
+import { BrowserDetectInfo } from './browser-detect.interface';
 import 'core-js/fn/array/filter';
 import 'core-js/fn/array/map';
 import 'core-js/fn/string/trim';
-export default function (userAgent: string): BrowserDetectInfo;
+export default function (userAgent?: string): BrowserDetectInfo;

--- a/dist/types/browser-detect.interface.d.ts
+++ b/dist/types/browser-detect.interface.d.ts
@@ -1,0 +1,17 @@
+export declare type BrowserDefinition = (string | RegExp)[];
+export interface OsDefinitionInterface {
+    name: string;
+    pattern: string;
+    value?: RegExpExecArray | null;
+}
+export declare type OsDefinition = OsDefinitionInterface | string;
+export declare type OsVersion = {
+    [key: string]: string;
+};
+export interface BrowserDetectInfo {
+    name?: string;
+    version?: string;
+    versionNumber?: number;
+    mobile?: boolean;
+    os?: string;
+}

--- a/dist/types/definitions.d.ts
+++ b/dist/types/definitions.d.ts
@@ -1,0 +1,4 @@
+import { BrowserDefinition, OsDefinition, OsVersion } from './browser-detect.interface';
+export declare const browsers: BrowserDefinition[];
+export declare const os: OsDefinition[];
+export declare const osVersions: OsVersion;

--- a/dist/types/detector.d.ts
+++ b/dist/types/detector.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="node" />
+import { BrowserDetectInfo } from './browser-detect.interface';
+import Process = NodeJS.Process;
+export declare class Detector {
+    private navigator;
+    private process;
+    private userAgent;
+    constructor(userAgent: string, navigator?: Navigator, process?: Process);
+    detect(): BrowserDetectInfo;
+    private checkBrowser();
+    private checkMobile();
+    private checkOs();
+    private getOsPattern(definition);
+    private handleMissingError();
+}

--- a/dist/types/regexp.d.ts
+++ b/dist/types/regexp.d.ts
@@ -1,0 +1,2 @@
+export declare const mobileRegExp: RegExp;
+export declare const mobilePrefixRegExp: RegExp;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     },
     "outDir": "./dist",
     "files": [
-        "src/browser-detect.ts"
+        "src/browser-detect.ts",
+        "src/browser-detect.interface.ts"
     ]
 }


### PR DESCRIPTION
import browser-detect module in *src/index.ts*:
```
import * as browser from 'browser-detect';
```

```
$ ./node_modules/.bin/tsc
node_modules/browser-detect/dist/types/browser-detect.d.ts(1,35): error TS2307: Cannot find module './interface'.
src/index.ts(5,13): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof "browser-detect/node_modules/browser-detect/dist/types/browser-detect"' has no compatible call signatures.
```